### PR TITLE
Change logic for strtol response in chk_fraction_digits_arg.

### DIFF
--- a/c_src/yang_core_grammar.c
+++ b/c_src/yang_core_grammar.c
@@ -477,7 +477,7 @@ chk_fraction_digits_arg(char *arg, void *opaque)
         return false;
     }
     i = strtol(arg, &end, 10);
-    if (*end == '\0') {
+    if (*end != '\0') {
         /* not an integer */
         return false;
     }


### PR DESCRIPTION
The previous code threw an error if strtol returned NULL. A NULL should be the valid case when the string is an integer. The result was that a valid fraction-digits argument was being flagged as an error.

```
../../models/yanger-bug-finder.yang:46: error: bad argument value "2", should be of type fraction-digits-arg
```
