### PR TITLE
swagger-plugin: Fix paths in case submodules are used

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ brew install erlang coreutils
 
 ```
 
-3. (optional) install lux to verify test cases 
+3. (optional) install lux to verify test cases
 
 ```
 ##deps
@@ -87,7 +87,7 @@ docker run -it -v ${PWD}:/workdir mbj4668/yanger -t expand -f swagger test_leaf.
 Sample Usage
 -----------------
 
-To create a Swagger JSON file from a yang file, you must first have a yang file, 
+To create a Swagger JSON file from a yang file, you must first have a yang file,
 for example, create the following `test_leaf.yang` file in your current working directory:
 
 ```
@@ -104,7 +104,7 @@ container test_vars{
 }
 ```
 
-Next you must tell yanger which format to output the yang into, in this example, 
+Next you must tell yanger which format to output the yang into, in this example,
 it is the swagger JSON format, giving the new file output name `test_leaf_now_swagger.json`:
 
 ```
@@ -128,8 +128,8 @@ $ more test_leaf_now_swagger.json
 .....
 ```
 
-You can for example take the Swagger file to the [Swaggerhub](https://app.swaggerhub.com/home) and auto create an SDK from 
-it in a python flask format or other languages. The Swaggerhub requires free registration. 
+You can for example take the Swagger file to the [Swaggerhub](https://app.swaggerhub.com/home) and auto create an SDK from
+it in a python flask format or other languages. The Swaggerhub requires free registration.
 
 
 For running tests
@@ -154,3 +154,15 @@ Hint for emacs users:
 (setq whitespace-style (quote (face trailing tabs lines)))
 
 and use whitespace-mode.
+
+
+
+Debugging
+=========
+If you wanted to use the erl-shell in order to debug you could:
+
+```
+erl -pa ./ebin
+yanger:main(["-p","<<YANG_PATH>>","-f","swagger","<<YANG_PATH>>/tailf-ncs.yang","-o","tailf-ncs.json"]).
+```
+

--- a/plugins/yanger_swagger.erl
+++ b/plugins/yanger_swagger.erl
@@ -890,10 +890,12 @@ is_data_def(Keyword, #yctx{env = #env{data_definition_stmts = D}}) ->
         andalso yang:map_is_key(Keyword, D).
 
 
+% In case of a submodule we need to use modulename not name.
 name(true = _IsTopNode, #sn{module = Module} = Sn, _Mod) ->
-    {_, ModuleName, _, _} = Module#module.stmt,
+    ModuleName = Module#module.modulename,
     LocalName = local_name(Sn),
     ?a2l(ModuleName) ++ ":" ++ LocalName;
+
 name(false = _IsTopNode, #sn{module = Module} = Sn, Mod) ->
     LocalName = local_name(Sn),
     if Module#module.modulename == Mod#module.modulename ->

--- a/plugins/yanger_swagger.erl
+++ b/plugins/yanger_swagger.erl
@@ -1762,7 +1762,7 @@ body(json, IsTop, Context, HttpMethod, PathType, Mode,
      fmt_type(Lvl + 2, {object, undefined}), ",\n",
      Indent6, "\"properties\": {",
      %% child properties
-     lists:join($,, ChildProperties), "\n",
+     lists:join($,, lists:usort(ChildProperties)), "\n",
      Indent6, "}\n",
      Indent4, "}\n",
      Indent2, "}"


### PR DESCRIPTION
Using the swagger plugin with submodules was not working properly. The namespace from the submodule was used instead of the parents-namespace. This showed up while generating swagger-files for nso-5.3.

Example
======
```
yanger -t expand -f swagger tailf-ncs.yang -> Inside the $NSO_DIR/src/ncs/yang-folder.
```
Submodules are seperately modeled due to code organization, however the namespace of the containers defined inside the submodules belong to the main-namespace, in this case tailf-ncs.

The swagger output is incorrect in this case and the swagger-document does not define the correct paths for the tailf-ncs:devices container.

```
$ yanger -t expand -f swagger tailf-ncs.yang --swagger-methods="get" | grep "data/"
    "/data/tailf-ncs-devices:devices": {
    "/data/tailf-ncs-devices:devices/device": {
    "/data/tailf-ncs-devices:devices/device={device-name}": {
    "/data/tailf-ncs-devices:devices/device={device-name}/name": {
    "/data/tailf-ncs-devices:devices/device={device-name}/sync-from": {
    "/data/tailf-ncs-devices:devices/device={device-name}/sync-from/input": {
    "/data/tailf-ncs-devices:devices/device={device-name}/sync-from/input/oempaloempa-name": {
    "/data/tailf-ncs-devices:devices/device={device-name}/sync-from/output": {
    "/data/tailf-ncs-devices:devices/device={device-name}/sync-from/output/data": {
    "/data/tailf-ncs-devices:devices/device={device-name}/sync-to": {
    "/data/tailf-ncs-devices:devices/device={device-name}/sync-to/input": {
    "/data/tailf-ncs-devices:devices/device={device-name}/sync-to/input/oempaloempa-name": {
    "/data/tailf-ncs-devices:devices/device={device-name}/sync-to/output": {
    "/data/tailf-ncs-devices:devices/device={device-name}/sync-to/output/data": {
```

The correct paths are:

```
sed 's#/data/tailf-ncs-devices:#/data/tailf-ncs:#g'
```

```
$ yanger -t expand -f swagger tailf-ncs.yang --swagger-methods="get" | grep "data/" | sed 's#/data/tailf-ncs-devices:#/data/tailf-ncs:#g'
    "/data/tailf-ncs:devices": {
    "/data/tailf-ncs:devices/device": {
    "/data/tailf-ncs:devices/device={device-name}": {
    "/data/tailf-ncs:devices/device={device-name}/name": {
    "/data/tailf-ncs:devices/device={device-name}/sync-from": {
    "/data/tailf-ncs:devices/device={device-name}/sync-from/input": {
    "/data/tailf-ncs:devices/device={device-name}/sync-from/input/oempaloempa-name": {
    "/data/tailf-ncs:devices/device={device-name}/sync-from/output": {
    "/data/tailf-ncs:devices/device={device-name}/sync-from/output/data": {
    "/data/tailf-ncs:devices/device={device-name}/sync-to": {
    "/data/tailf-ncs:devices/device={device-name}/sync-to/input": {
    "/data/tailf-ncs:devices/device={device-name}/sync-to/input/oempaloempa-name": {
    "/data/tailf-ncs:devices/device={device-name}/sync-to/output": {
    "/data/tailf-ncs:devices/device={device-name}/sync-to/output/data": {
```

Would be interested to know if this was/is the correct approach! 
Kind regards,

Fabian
