### PR TITLE
Report proper error if leafref path is invalid.

### DIFF
--- a/src/yang_types.erl
+++ b/src/yang_types.erl
@@ -1337,6 +1337,10 @@ validate_leafref_path(#leafref_type_spec{path_stmt = Stmt} = TypeSpec,
             {false, Error}
     end.
 
+validate_leafref_path0(#leafref_type_spec{path = undefined},
+		       _InitCursor, _Visited, Ctx) ->
+    %% path undefined means an error in the leafref definition.
+    {false, Ctx};
 validate_leafref_path0(#leafref_type_spec{path = Path},
                        InitCursor, Visited, Ctx) ->
     case
@@ -1368,6 +1372,8 @@ validate_leafref_path0(#leafref_type_spec{path = Path},
                             {circular, Ctx1};
                         {true, _, FinalSn} ->
                             {true, TargetSn, FinalSn};
+			{false, Ctx1} when is_record(Ctx1, yctx) ->
+			    {false, Ctx1};
                         {false, Error} ->
                             %% ignore other errors, if any; they are
                             %% reported when the leafref is checked

--- a/test/lux/ENG-23621-leafref-has-invalid-path/Makefile
+++ b/test/lux/ENG-23621-leafref-has-invalid-path/Makefile
@@ -1,0 +1,8 @@
+include ../../support/*_testcases.mk
+
+build:
+
+clean:
+	rm -rf lux_logs
+
+.PHONY: build clean

--- a/test/lux/ENG-23621-leafref-has-invalid-path/run.lux
+++ b/test/lux/ENG-23621-leafref-has-invalid-path/run.lux
@@ -1,0 +1,19 @@
+[doc]
+Check invalid path in leafref path handled gracefully.
+
+If there is a leafref path that points to an invalid path eg. invalid namespace
+due to not imported modules, or XPATH compilation failed for some reason,
+yanger shall report a proper error. This is the case for most of the scenarios
+but when a leafref points to another leafref that has an invalid path, we were
+getting an internal error previously. This test ensures that yanger reports a
+proper error message.
+[enddoc]
+
+################################################################################
+
+[shell yanger]
+    -function_clause
+    !env YANGERROR=super-pruned yanger --verbose test.yang
+    ???test.yang:11: error: XPath error: Invalid namespace prefix: ngsub
+    !echo ==$$?==
+    ?==1==

--- a/test/lux/ENG-23621-leafref-has-invalid-path/test.yang
+++ b/test/lux/ENG-23621-leafref-has-invalid-path/test.yang
@@ -1,0 +1,14 @@
+module test {
+  namespace "http://acme/test";
+  prefix test;
+  leaf name {
+    type leafref {
+      path '../name2';
+    }
+  }
+  leaf name2 {
+    type leafref {
+      path '/ngsub:sub-vpns';
+    }
+  }
+}


### PR DESCRIPTION
Fix an internal_error issue when a leafref pointing another leafref
with invalid path.