### PR TITLE
[ENG-24068] Post expand leafref from submodule.

### DIFF
--- a/test/lux/ENG-24068-submodule-post-expand-leafref/Makefile
+++ b/test/lux/ENG-24068-submodule-post-expand-leafref/Makefile
@@ -1,0 +1,6 @@
+include ../../support/*_testcases.mk
+
+build:
+
+clean: iclean
+	rm -rf lux_logs

--- a/test/lux/ENG-24068-submodule-post-expand-leafref/run.lux
+++ b/test/lux/ENG-24068-submodule-post-expand-leafref/run.lux
@@ -1,0 +1,19 @@
+[doc]
+Return proper error if a leafref refers to a conditional leaf that does not exist due to the condtition.
+
+RFC-7950 states:
+  "If the leaf that the leafref refers to is conditional based on one or
+   more features (see Section 7.20.2), then the leaf with the leafref
+   type MUST also be conditional based on at least the same set of features." 
+
+[enddoc]
+
+################################################################################
+
+[shell test]
+    !env yanger --print-error-code test.yang --features test:
+    ???./subtest.yang:9: YANG_ERR_NODE_NOT_FOUND3
+    ???./subtest.yang:15: YANG_ERR_NODE_NOT_FOUND2
+    -==0==
+    !echo ==$$?==
+    ?==1==

--- a/test/lux/ENG-24068-submodule-post-expand-leafref/subtarget.yang
+++ b/test/lux/ENG-24068-submodule-post-expand-leafref/subtarget.yang
@@ -1,0 +1,14 @@
+submodule subtarget {
+  yang-version 1.1;
+  belongs-to test {
+    prefix t;
+  }
+  feature name;
+
+  container top{
+    leaf subtarget {
+      if-feature name;
+      type string;
+    }
+  }
+}

--- a/test/lux/ENG-24068-submodule-post-expand-leafref/subtest.yang
+++ b/test/lux/ENG-24068-submodule-post-expand-leafref/subtest.yang
@@ -1,0 +1,18 @@
+submodule subtest {
+  yang-version 1.1;
+  belongs-to test {
+    prefix t;
+  }
+
+  leaf target {
+    type leafref {
+      path '/t:top/t:subtarget';
+    }
+  }
+
+  leaf name {
+    type leafref {
+      path '/t:basename';
+    }
+  }
+}

--- a/test/lux/ENG-24068-submodule-post-expand-leafref/test.yang
+++ b/test/lux/ENG-24068-submodule-post-expand-leafref/test.yang
@@ -1,0 +1,13 @@
+module test {
+  yang-version 1.1;
+  namespace "http://acme/test";
+  prefix t;
+  include subtarget;
+  include subtest;
+  
+  leaf basename {
+    if-feature name;
+    type string;
+    default "testname";
+  }
+}


### PR DESCRIPTION
This PR might not be the best solution in its current shape but it addresses an issue when a leafref defined in a Yang 1.1 submodule that refers to a leaf in base module which is dependent on a feature. Currently yang does not check if the leafref is valid. This PR introduces the checks by running post expand hooks for Yang 1.1 submodules when processing the base module. The checks on Yang 1.1 submodules were removed previously by commit id c5c6930e. This PR does not revert that commit but introduces a work around.
 
--- commit message ---
Add a function clause to yang:post_expand_sn/4 to match
SNs defined in Yang 1.1 submodules and run post expand SN
hooks when processing the base module.

yang:post_expand_module/2 was not called for Yang 1.1
Submodules since commit c5c6930e.
--- commit message ---

Another possible approach might be to disable checks for all submodules (YANg version 1 and 1.1) in yang:post_add_modules/1 and change the function clause in yang:post_expand_sn/4 to match "a module or its submodules".