### PR TITLE
Issue/augment key not mandatory

### DIFF
--- a/test/lux/tree/parent.yang
+++ b/test/lux/tree/parent.yang
@@ -1,0 +1,11 @@
+module parent {
+  namespace urn:parent;
+  prefix parent;
+
+  container parent-container {
+    // to be augmented by small6
+  }
+  container parent-container-2 {
+    // to be augmented by small6
+  }
+}

--- a/test/lux/tree/small6.lux
+++ b/test/lux/tree/small6.lux
@@ -1,0 +1,16 @@
+[doc text sx:structure]
+
+[shell yanger]
+    !yanger -f tree small6.yang
+    """???
+    module: small6
+
+      augment /parent:parent-container:
+        +--rw test-list* [test-key]
+           +--rw test-key    string
+           +--rw dummy?      uint16
+      augment /parent:parent-container-2:
+        +--rw test-list* [test-key]
+           +--rw test-key    string
+           +--rw dummy?      uint16
+    """

--- a/test/lux/tree/small6.yang
+++ b/test/lux/tree/small6.yang
@@ -1,0 +1,36 @@
+module small6 {
+  namespace urn:r;
+  prefix r;
+
+  import parent {
+    prefix parent;
+  }
+
+  augment "/parent:parent-container" {
+    list test-list {
+      key test-key;
+
+      leaf test-key {
+        type string;
+      }
+
+      leaf dummy {
+        type uint16;
+      }
+    }
+  }
+
+  augment "/parent:parent-container-2" {
+    list test-list {
+      key test-key;
+
+      leaf test-key {
+        type string;
+      }
+
+      leaf dummy {
+        type uint16;
+      }
+    }
+  }
+}

--- a/test/lux/tree/tree_plugin_macro.lux
+++ b/test/lux/tree/tree_plugin_macro.lux
@@ -31,6 +31,13 @@
     ## In order for the #groupings{} to be correct, I think we must
     ## topo sort all groupings and process them in the correct order.
     #[invoke tree_compare small5.yang]
+
+    ## FIXME: pyang is not sending the correct output as per
+    ##  RFC https://tools.ietf.org/html/rfc8340#section-2
+    ## There should be a newline between module name and newline
+    ## cf https://github.com/mbj4668/yanger/pull/17 for discussion
+    #[invoke tree_compare small6.yang]
+
     [invoke tree_compare a.yang]
     [invoke tree_compare x.yang]
 


### PR DESCRIPTION
Issue:

When using the tree plugin the keys of a list inside an augment are being marked as optional (the parent model is in the same folder):

```
yanger -f tree small6.yang
```
output (notice test-key is marked as optional):
```                                                                                                                                                   
module: small6

  augment /parent:parent-container:
    +--rw test-list* [test-key]
       +--rw test-key?    string
       +--rw dummy?      uint16
```

For comparison here is pyang output for the same model:
```
pyang -f tree small6.yang                                                                                                                                                      
```
output:
```

module: small6
  augment /parent:parent-container:
    +--rw test-list* [test-key]
       +--rw test-key    string
       +--rw dummy?      uint16
```

This is due to the following line in the yang tree plugin:
```
             NewName =
                 case
                     PKey /= undefined
                     andalso ?in(Sn#sn.name, PKey)
```

the andalso statement will always be false inside an augment as the name looks like `{_, name}`

I have integrated a fix in this PR that makes the logic work and I have added a test - however I am getting an issue with the way pyang and yanger tree plugins are inserting new lines in this scenario.


**Remaining problem on which I need help:** The output from pyang and yanger is different in this case because of the newline inserted before `module` in pyang and after `module` in yanger