### PR TITLE
 Leading zeros of a decimal64 value should be prohibited

### DIFF
--- a/src/yang_types.erl
+++ b/src/yang_types.erl
@@ -406,8 +406,8 @@ decimal64_type_spec_fun({parse, Val, _Pos}, #type{type_spec = TypeSpec},
             {ok, Max};
         _ ->
             try
-                RE = ["^\\s*([+-]?\\d+)(\\.(\\d+))?\\s*$"],
-                {match, [I, F]} = re:run(Val, RE, [{capture, [1,3], list}]),
+                RE = ["^\\s*([+-]?(0|([1-9]\\d*)))(\\.(\\d+))?\\s*$"],
+                {match, [I, F]} = re:run(Val, RE, [{capture, [1,5], list}]),
                 if length(F) > FD ->
                         {error, "too many fraction digits"};
                    true ->

--- a/test/lux/bad/decimal.yang
+++ b/test/lux/bad/decimal.yang
@@ -1,0 +1,38 @@
+module decimal {
+  namespace urn:decimal;
+  prefix decimal;
+ 
+  typedef myDecimal {
+    type decimal64 {
+      fraction-digits 2;
+      range "0 .. 3.14 | 10 | 20 ..max";
+    }
+  }
+
+  leaf l {
+    type myDecimal {
+      fraction-digits 3; // LINE: YANG_ERR_BAD_RESTRICTION
+    }
+  }
+
+  leaf l2 {
+    type myDecimal {
+      range "5.55"; // LINE: YANG_ERR_BAD_RANGE_VALUE
+    }
+  }
+
+  leaf l3 {
+    type myDecimal;
+    default 2.000; // LINE: YANG_ERR_TYPE_VALUE
+  }
+
+  leaf l4 {
+    type myDecimal;
+    default 02.01; // LINE: YANG_ERR_TYPE_VALUE
+  }
+
+  leaf l5 {
+    type myDecimal;
+    default 0.01;
+  }
+}


### PR DESCRIPTION
Hi Martin,

As description in [RFC7950#section-9.3.2](http://tools.ietf.org/html/rfc7950#section-9.3.2),  leading zeros of a decimal64 value are prohibited,  `pyang` reports  error, but `yanger` not.  I think  this is a bug  and fix it.  Please take a look.

