### PR TITLE
Add different yang version checked in include and import (sub)modules

### DIFF
--- a/src/yang_error.erl
+++ b/src/yang_error.erl
@@ -166,8 +166,12 @@ codes() ->
         "the type \"~s\" cannot have a default value"}
      , {'YANG_ERR_BAD_IMPORT', error,
         "expected module, found submodule at ~s"}
+     , {'YANG_ERR_BAD_IMPORT_YANG_VERSION', error,
+        "a version ~s module cannot import a version ~s module by revision"}
      , {'YANG_ERR_BAD_INCLUDE', error,
         "expected submodule, found module at ~s"}
+     , {'YANG_ERR_BAD_INCLUDE_YANG_VERSION', error,
+        "cannot include a version ~s submodule in a version ~s module"}
      , {'YANG_ERR_BAD_KEY', error,
         "the key ~s does not reference an existing leaf"}
      , {'YANG_ERR_BAD_LENGTH', error,

--- a/test/lux/yang-1.1/impinc.yang
+++ b/test/lux/yang-1.1/impinc.yang
@@ -9,7 +9,7 @@ module impinc {
     reference "RFC 6991";       // new in 1.1
   }
 
-  include incsub {
+  include incsub {              // LINE: YANG_ERR_BAD_INCLUDE_YANG_VERSION
     description bar;            // new in 1.1.
     reference "RFC XXXX";       // new in 1.1
   }

--- a/test/lux/yang-1.1/impincyv.yang
+++ b/test/lux/yang-1.1/impincyv.yang
@@ -1,0 +1,21 @@
+module impincyv {
+  yang-version 1;
+  namespace urn:impinc-yv;
+  prefix iiyv;
+
+  import impyv1 {
+    prefix iyv1;
+  }
+
+  import impyv2 { // LINE: YANG_ERR_BAD_IMPORT_YANG_VERSION
+    revision-date 2020-08-30;
+    prefix iyv2;
+  }
+
+  include incsubyv1;
+  include incsubyv2; // LINE: YANG_ERR_BAD_INCLUDE_YANG_VERSION
+
+  leaf l {
+    type iyv1:myInt;
+  }
+}

--- a/test/lux/yang-1.1/impyv1.yang
+++ b/test/lux/yang-1.1/impyv1.yang
@@ -1,0 +1,9 @@
+module impyv1 {
+  namespace urn:impyv1;
+  yang-version 1.1;
+  prefix iyv1;
+
+  typedef myInt {
+    type int32;
+  }
+}

--- a/test/lux/yang-1.1/impyv2.yang
+++ b/test/lux/yang-1.1/impyv2.yang
@@ -1,0 +1,13 @@
+module impyv2 {
+  namespace urn:impyv2;
+  yang-version 1.1;
+  prefix iyv2;
+
+  revision 2020-08-30 {
+    description "test";
+  }
+
+  leaf unkown {
+    type empty;
+  } 
+}

--- a/test/lux/yang-1.1/incsubyv1.yang
+++ b/test/lux/yang-1.1/incsubyv1.yang
@@ -1,0 +1,9 @@
+submodule incsubyv1 {
+  belongs-to impincyv {
+    prefix iiyv;
+  }
+
+  leaf yv1 {
+    type int32;
+  }
+}

--- a/test/lux/yang-1.1/incsubyv2.yang
+++ b/test/lux/yang-1.1/incsubyv2.yang
@@ -1,0 +1,10 @@
+submodule incsubyv2 {
+  yang-version 1.1;
+  belongs-to impincyv {
+    prefix iiyv;
+  }
+
+  leaf yv2 {
+    type int32;
+  }
+}

--- a/test/lux/yang-1.1/u.yang
+++ b/test/lux/yang-1.1/u.yang
@@ -3,7 +3,7 @@ module u {
   namespace urn:u;
   prefix u;
 
-  include usub; // error; bad version in submodule
+  include usub; // error; bad version in submodule - LINE: YANG_ERR_BAD_INCLUDE_YANG_VERSION
   revision 2015-11-06;
   feature foo;
   feature bar;


### PR DESCRIPTION
Hi Martin,

As description in [RFC7950#section-12](https://tools.ietf.org/html/rfc7950#section-12), this PR resolved  `YANG Version 1.1` iscoexitence with  `verison 1`, please review it.