### PR TITLE
A deviated type is resolved in deviating module scope

### DIFF
--- a/include/yang.hrl
+++ b/include/yang.hrl
@@ -113,6 +113,9 @@
           %% pointer to our module.  NOTE: the module record is not
           %% yet complete; specifically its .children is [].
           module :: 'undefined' | yang:module_rec(),
+          %% pointer to deviating module. Used for type scope resolve.
+          deviating_resolve_data :: 'undefined' |
+                                    {#typedefs{}, yang:module_rec()},
           %% 'ignore' means that the config statement should be ignored
           %% for this subtree.
           config :: 'undefined' | 'ignore' | 'true' | 'false',
@@ -562,7 +565,9 @@
           %% using them.
           bad_typedefs :: yang:map({Name :: atom(), yang:modrev()}, #yerror{}),
           max_status :: 'undefined' | yang:yang_status(),
-          pmap = yang:map_new() :: yang:map0() % used by plugins
+          pmap = yang:map_new() :: yang:map0(), % used by plugins
+          %% Used during deviation type resolving
+          target_name :: atom() | undefined
          }).
 
 %% See yang:cursor_move()

--- a/src/yang_xpath.erl
+++ b/src/yang_xpath.erl
@@ -77,7 +77,11 @@ compile(Str, Pos, M, Strict, Ctx0) ->
             Prefixes = xpath_rewrite:fold_expr(fun prefix/2, [], Q),
             Ctx2 = lists:foldl(
                      fun(P, Ctx1) ->
-                             yang:mark_import_as_used(Name, P, Ctx1)
+                             %% The prefix must be marked as used in
+                             %% the target module also.
+                             T = Ctx1#yctx.target_name,
+                             Ctx2 = yang:mark_import_as_used(T, P, Ctx1),
+                             yang:mark_import_as_used(Name, P, Ctx2)
                      end, Ctx0, Prefixes),
             case xpath_compile1(Q, PrefixNsMap) of
                 {ok, CompiledXPath} ->

--- a/test/lux/eng-25448_deviated_type_scope/Makefile
+++ b/test/lux/eng-25448_deviated_type_scope/Makefile
@@ -1,0 +1,8 @@
+
+build:
+	lux run.lux
+
+clean:
+	rm -f *.fxs
+
+.PHONY: build clean

--- a/test/lux/eng-25448_deviated_type_scope/cli-server.yang
+++ b/test/lux/eng-25448_deviated_type_scope/cli-server.yang
@@ -1,0 +1,73 @@
+module cli-server {
+
+  yang-version 1.1;
+
+  namespace "urn:example";
+  prefix x;
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+  import ietf-tcp-server {
+    prefix tcps;
+  }
+
+  typedef ssh-port-number {
+    type inet:port-number {
+      range "22 | 1024..49151 | 49500..max";
+    }
+  }
+
+  grouping ssh-server-stack-grouping {
+    container ssh {
+      container tcp-server-parameters {
+        uses tcps:tcp-server-grouping {
+          refine "local-port" {
+            default "22";
+          }
+        }
+      }
+    } /* container ssh */
+  } /* grouping ssh-server-stack-grouping */
+
+  grouping cli-server-listen-stack-grouping {
+    leaf enabled {
+      type boolean;
+      default false;
+    }
+    choice transport {
+      case ssh {
+        uses ssh-server-stack-grouping;
+      }
+    }
+  } /* cli-server-listen-stack-grouping */
+
+  grouping cli-server-app-grouping {
+    container listen {
+      leaf idle-timeout {
+        type uint32;
+        units "seconds";
+        default 900;
+      }
+      list endpoint {
+        key name;
+        leaf name {
+          type string {
+            length "1 .. 32";
+          }
+        }
+        uses cli-server-listen-stack-grouping;
+      }
+    }
+  } /* grouping cli-server-app-grouping */
+
+  container cli-server {
+    uses cli-server-app-grouping;
+  } /* container cli-server */
+
+  deviation "/cli-server/listen/endpoint/transport/ssh/ssh/tcp-server-parameters/local-port" {
+    deviate replace {
+      type ssh-port-number;
+    }
+  }
+}

--- a/test/lux/eng-25448_deviated_type_scope/confd.conf
+++ b/test/lux/eng-25448_deviated_type_scope/confd.conf
@@ -1,0 +1,322 @@
+<!-- -*- nxml -*- -->
+<!-- This configuration is good for the examples, but are in many ways
+     atypical for a production system. It also does not contain all
+     possible configuration options.
+
+     Better starting points for a production confd.conf configuration 
+     file would be confd.conf.example. For even more information, see 
+     the confd.conf man page.
+     
+     E.g. references to current directory are not good practice in a
+     production system, but makes it easier to get started with
+     this example. There are many references to the current directory
+     in this example configuration.
+-->
+
+<confdConfig xmlns="http://tail-f.com/ns/confd_cfg/1.0">
+  <!-- The loadPath is searched for .fxs files, javascript files, etc.
+       NOTE: if you change the loadPath, the daemon must be restarted,
+       or the "In-service Data Model Upgrade" procedure described in
+       the User Guide can be used - 'confd - -reload' is not enough.
+  -->
+  <loadPath>
+    <dir>.</dir>
+  </loadPath>
+
+ <!-- create a hidden group -->
+ <hideGroup>
+   <name>HiddenGroup</name>
+ </hideGroup>
+
+  <stateDir>.</stateDir>
+
+
+<!--
+    <historyMaxSize>200</historyMaxSize>
+-->
+  <defaultHandlingMode>report-all</defaultHandlingMode>
+  <enableAttributes>true</enableAttributes>
+
+  <cli>
+    <restrictedFileAccess>false</restrictedFileAccess>
+    <showMatchBeforePossible>true</showMatchBeforePossible>
+    <caseInsensitiveKeys>false</caseInsensitiveKeys>
+    <allowAbbrevKeys>false</allowAbbrevKeys>
+    <trimDefaultSave>true</trimDefaultSave>
+    <cTabInfo>true</cTabInfo>
+  <showAnnotations>true</showAnnotations>
+  </cli>
+
+  <cdb>
+    <enabled>true</enabled>
+    <dbDir>./confd-cdb</dbDir>
+    <operational>
+      <enabled>true</enabled>
+    </operational>
+  </cdb> 
+
+  <rollback>
+    <enabled>true</enabled>
+    <directory>./confd-cdb</directory>
+  </rollback>
+
+  <!-- These keys are used to encrypt values adhering to the types
+       tailf:des3-cbc-encrypted-string and tailf:aes-cfb-128-encrypted-string
+       as defined in the tailf-common YANG module. These types are
+       described in confd_types(3). 
+  -->
+  <encryptedStrings>
+    <DES3CBC>
+      <key1>0123456789abcdef</key1>
+      <key2>0123456789abcdef</key2>
+      <key3>0123456789abcdef</key3>
+      <initVector>0123456789abcdef</initVector>
+    </DES3CBC>
+    
+    <AESCFB128>
+      <key>0123456789abcdef0123456789abcdef</key>
+      <initVector>0123456789abcdef0123456789abcdef</initVector>
+    </AESCFB128>
+  </encryptedStrings>
+
+  <logs>
+    <!-- Shared settings for how to log to syslog.
+         Each log can be configured to log to file and/or syslog.  If a
+         log is configured to log to syslog, the settings below are used.
+    -->
+    <syslogConfig>
+      <!-- facility can be 'daemon', 'local0' ... 'local7' or an integer -->
+      <facility>daemon</facility>
+      <!-- if udp is not enabled, messages will be sent to local syslog -->
+      <udp>
+        <enabled>false</enabled>
+        <host>syslogsrv.example.com</host>
+        <port>514</port>
+      </udp>
+    </syslogConfig>
+
+    <!-- 'confdlog' is a normal daemon log.  Check this log for
+         startup problems of confd itself.
+         By default, it logs directly to a local file, but it can be
+         configured to send to a local or remote syslog as well.
+    -->
+    <confdLog>
+      <enabled>true</enabled>
+      <file>
+        <enabled>true</enabled>
+        <name>./confd.log</name>
+      </file>
+      <syslog>
+        <enabled>true</enabled>
+        <facility>23</facility>
+      </syslog>
+    </confdLog>
+
+    <!-- The developer logs are supposed to be used as debug logs
+         for troubleshooting user-written javascript and c code.  Enable
+         and check these logs for problems with validation code etc.
+    -->
+    <developerLog>
+      <enabled>true</enabled>
+      <file>
+        <enabled>true</enabled>
+        <name>./devel.log</name>
+      </file>
+      <syslog>
+        <enabled>false</enabled>
+      </syslog>
+    </developerLog>
+
+    <developerLogLevel>trace</developerLogLevel>
+
+     <errorLog>
+        <enabled>true</enabled>
+        <filename>./error.log</filename>
+     </errorLog>
+
+    <auditLog>
+      <enabled>true</enabled>
+      <file>
+        <enabled>true</enabled>
+        <name>./audit.log</name>
+      </file>
+      <syslog>
+        <enabled>true</enabled>
+      </syslog>
+    </auditLog>
+
+    <!-- The netconf log can be used to troubleshoot NETCONF operations,
+         such as checking why e.g. a filter operation didn't return the
+         data requested.
+    -->
+    <netconfLog>
+      <enabled>true</enabled>
+      <file>
+        <enabled>true</enabled>
+        <name>./netconf.log</name>
+      </file>
+      <syslog>
+        <enabled>false</enabled>
+      </syslog>
+    </netconfLog>
+
+    <webuiBrowserLog>
+      <enabled>true</enabled>
+      <filename>./browser.log</filename>
+    </webuiBrowserLog>
+
+    <webuiAccessLog>
+      <enabled>true</enabled>
+      <dir>./</dir>
+    </webuiAccessLog>
+
+    <netconfTraceLog>
+      <enabled>true</enabled>
+      <filename>./netconf.trace</filename>
+      <format>pretty</format>
+    </netconfTraceLog>
+
+    <xpathTraceLog>
+      <enabled>false</enabled>
+      <filename>./xpath.trace</filename>
+    </xpathTraceLog>
+
+  </logs>
+
+  <!-- Defines which datastores confd will handle. -->
+  <datastores>
+    <!-- 'startup' means that the system keeps separate running and
+         startup configuration databases.  When the system reboots for
+         whatever reason, the running config database is lost, and the
+         startup is read.
+         Enable this only if your system uses a separate startup and
+         running database.
+    -->
+    <startup>
+      <enabled>false</enabled>
+    </startup>
+
+    <!-- The 'candidate' is a shared, named alternative configuration
+         database which can be modified without impacting the running
+         configuration.  Changes in the candidate can be commit to running,
+         or discarded.
+         Enable this if you want your users to use this feature from
+         NETCONF, CLI or WebGUI, or other agents.
+    -->
+    <candidate>
+      <enabled>false</enabled>
+      <!-- By default, confd implements the candidate configuration
+           without impacting the application.  But if your system
+           already implements the candidate itself, set 'implementation' to
+           'external'.
+      -->
+      <!--implementation>external</implementation-->
+      <implementation>confd</implementation>
+      <storage>auto</storage>
+      <filename>./confd_candidate.db</filename>
+    </candidate>
+
+    <!-- By default, the running configuration is writable.  This means
+         that the application must be prepared to handle changes to
+         the configuration dynamically.  If this is not the case, set
+         'access' to 'read-only'.  If running is read-only, 'startup'
+         must be enabled, and 'candidate' must be disabled.  This means that
+         the application reads the configuration at startup, and then
+         the box must reboort in order for the application to re-read it's
+         configuration.
+
+         NOTE: this is not the same as the NETCONF capability
+         :writable-running, which merely controls which NETCONF
+         operations are allowed to write to the running configuration.
+    -->
+    <running>  
+      <access>read-write</access>
+    </running>
+  </datastores>
+
+  <aaa>
+    <sshServerKeyDir>./ssh-keydir</sshServerKeyDir>
+  </aaa>
+
+
+ <!-- Enable the RESTCONF interface -->
+<restconf>
+  <enabled>true</enabled>
+</restconf>
+
+  <netconf>
+    <enabled>true</enabled>
+    <transport>
+      <ssh>
+        <enabled>true</enabled>
+        <ip>0.0.0.0</ip>
+        <port>2022</port>
+      </ssh>
+
+      <!-- NETCONF over TCP is not standardized, but it can be useful
+           during development in order to use e.g. netcat for scripting.
+      -->
+      <tcp>
+        <enabled>true</enabled>
+        <ip>127.0.0.1</ip>
+        <port>2023</port>
+      </tcp>
+    </transport>
+
+    <capabilities>
+      <!-- enable only if /confdConfig/datastores/startup is enabled -->
+      <startup>
+        <enabled>false</enabled>
+      </startup>
+
+      <!-- enable only if /confdConfig/datastores/candidate is enabled -->
+      <candidate>
+        <enabled>false</enabled>
+      </candidate>
+
+      <confirmed-commit>
+        <enabled>false</enabled>
+      </confirmed-commit>
+
+      <!--
+           enable only if /confdConfig/datastores/running/access is read-write
+      -->
+      <writable-running>
+        <enabled>true</enabled>
+      </writable-running>
+
+      <rollback-on-error>
+        <enabled>true</enabled>
+      </rollback-on-error>
+
+      <actions>
+        <enabled>true</enabled>
+      </actions>
+
+    </capabilities>
+  </netconf>
+  <webui>
+    <enabled>true</enabled>
+    
+    <transport>
+      <tcp>
+        <enabled>true</enabled>
+        <ip>0.0.0.0</ip>
+        <port>8008</port>
+      </tcp>
+      
+      <ssl>
+        <enabled>true</enabled>
+        <ip>0.0.0.0</ip>
+        <port>8888</port>
+      </ssl>
+    </transport>
+    
+    <cgi>
+      <enabled>true</enabled>
+      <php>
+        <enabled>true</enabled>
+      </php>
+    </cgi>
+  </webui>
+</confdConfig>

--- a/test/lux/eng-25448_deviated_type_scope/ietf-tcp-common.yang
+++ b/test/lux/eng-25448_deviated_type_scope/ietf-tcp-common.yang
@@ -1,0 +1,121 @@
+module ietf-tcp-common {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-tcp-common";
+  prefix tcpcmn;
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group and the
+     IETF TCP Maintenance and Minor Extensions (TCPM) Working Group";
+
+  contact
+    "WG Web:   <http://datatracker.ietf.org/wg/netconf/>
+               <http://datatracker.ietf.org/wg/tcpm/>
+     WG List:  <mailto:netconf@ietf.org>
+               <mailto:tcpm@ietf.org>
+     Authors:  Kent Watsen <mailto:kent+ietf@watsen.net>
+               Michael Scharf
+               <mailto:michael.scharf@hs-esslingen.de>";
+
+  description
+    "This module defines reusable groupings for TCP commons that
+     can be used as a basis for specific TCP common instances.
+
+     Copyright (c) 2020 IETF Trust and the persons identified
+     as authors of the code. All rights reserved.
+
+     Redistribution and use in source and binary forms, with
+     or without modification, is permitted pursuant to, and
+     subject to the license terms contained in, the Simplified
+     BSD License set forth in Section 4.c of the IETF Trust's
+     Legal Provisions Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC DDDD
+     (https://www.rfc-editor.org/info/rfcDDDD); see the RFC
+     itself for full legal notices.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL',
+     'SHALL NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED',
+     'NOT RECOMMENDED', 'MAY', and 'OPTIONAL' in this document
+     are to be interpreted as described in BCP 14 (RFC 2119)
+     (RFC 8174) when, and only when, they appear in all
+     capitals, as shown here.";
+
+  revision 2020-08-20 {
+    description
+      "Initial version";
+    reference
+      "RFC DDDD: YANG Groupings for TCP Clients and TCP Servers";
+  }
+
+  // Features
+  feature keepalives-supported {
+    description
+      "Indicates that keepalives are supported.";
+  }
+
+  // Groupings
+
+  grouping tcp-common-grouping {
+    description
+      "A reusable grouping for configuring TCP parameters common
+       to TCP connections as well as the operating system as a
+       whole.";
+    container keepalives {
+      if-feature "keepalives-supported";
+      presence
+       "Indicates that keepalives are enabled.  Present so that
+        the decendant nodes' 'mandatory true' doesn't imply that
+        this node  must be configured.";
+      description
+        "Configures the keep-alive policy, to proactively test the
+         aliveness of the TCP peer.  An unresponsive TCP peer is
+         dropped after approximately (idle-time + max-probes
+         * probe-interval) seconds.";
+      leaf idle-time {
+        type uint16 {
+          range "1..max";
+        }
+        units "seconds";
+        mandatory true;
+        description
+          "Sets the amount of time after which if no data has been
+           received from the TCP peer, a TCP-level probe message
+           will be sent to test the aliveness of the TCP peer.
+           Two hours (7200 seconds) is safe value, per RFC 1122.";
+        reference
+          "RFC 1122:
+            Requirements for Internet Hosts -- Communication Layers";
+      }
+      leaf max-probes {
+        type uint16 {
+          range "1..max";
+        }
+        mandatory true;
+        description
+          "Sets the maximum number of sequential keep-alive probes
+           that can fail to obtain a response from the TCP peer
+           before assuming the TCP peer is no longer alive.";
+      }
+      leaf probe-interval {
+        type uint16 {
+          range "1..max";
+        }
+        units "seconds";
+        mandatory true;
+        description
+          "Sets the time interval between failed probes. The interval
+           SHOULD be significantly longer than one second in order to
+           avoid harm on a congested link.";
+      }
+    } // container keepalives
+  } // grouping tcp-common-grouping
+
+  grouping tcp-connection-grouping {
+    description
+      "A reusable grouping for configuring TCP parameters common
+       to TCP connections.";
+     uses tcp-common-grouping;
+  }
+
+}

--- a/test/lux/eng-25448_deviated_type_scope/ietf-tcp-server.yang
+++ b/test/lux/eng-25448_deviated_type_scope/ietf-tcp-server.yang
@@ -1,0 +1,114 @@
+module ietf-tcp-server {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-tcp-server";
+  prefix tcps;
+
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+
+  import ietf-tcp-common {
+    prefix tcpcmn;
+    reference
+      "RFC DDDD: YANG Groupings for TCP Clients and TCP Servers";
+  }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group and the
+     IETF TCP Maintenance and Minor Extensions (TCPM) Working Group";
+
+  contact
+    "WG Web:   <http://datatracker.ietf.org/wg/netconf/>
+               <http://datatracker.ietf.org/wg/tcpm/>
+     WG List:  <mailto:netconf@ietf.org>
+               <mailto:tcpm@ietf.org>
+     Authors:  Kent Watsen <mailto:kent+ietf@watsen.net>
+               Michael Scharf
+               <mailto:michael.scharf@hs-esslingen.de>";
+
+  description
+    "This module defines reusable groupings for TCP servers that
+     can be used as a basis for specific TCP server instances.
+
+     Copyright (c) 2020 IETF Trust and the persons identified
+     as authors of the code. All rights reserved.
+
+     Redistribution and use in source and binary forms, with
+     or without modification, is permitted pursuant to, and
+     subject to the license terms contained in, the Simplified
+     BSD License set forth in Section 4.c of the IETF Trust's
+     Legal Provisions Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC DDDD
+     (https://www.rfc-editor.org/info/rfcDDDD); see the RFC
+     itself for full legal notices.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL',
+     'SHALL NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED',
+     'NOT RECOMMENDED', 'MAY', and 'OPTIONAL' in this document
+     are to be interpreted as described in BCP 14 (RFC 2119)
+     (RFC 8174) when, and only when, they appear in all
+     capitals, as shown here.";
+
+  revision 2020-08-20 {
+    description
+      "Initial version";
+    reference
+      "RFC DDDD: YANG Groupings for TCP Clients and TCP Servers";
+  }
+
+  // Features
+
+  feature tcp-server-keepalives {
+    description
+      "Per socket TCP keepalive parameters are configurable for
+       TCP servers on the server implementing this feature.";
+  }
+
+  // Groupings
+
+  grouping tcp-server-grouping {
+    description
+      "A reusable grouping for configuring a TCP server.
+
+       Note that this grouping uses fairly typical descendent
+       node names such that a stack of 'uses' statements will
+       have name conflicts.  It is intended that the consuming
+       data model will resolve the issue (e.g., by wrapping
+       the 'uses' statement in a container called
+       'tcp-server-parameters').  This model purposely does
+       not do this itself so as to provide maximum flexibility
+       to consuming models.";
+    leaf local-address {
+      type inet:ip-address;
+      mandatory true;
+      description
+        "The local IP address to listen on for incoming
+         TCP client connections.  INADDR_ANY (0.0.0.0) or
+         INADDR6_ANY (0:0:0:0:0:0:0:0 a.k.a. ::) MUST be
+         used when the server is to listen on all IPv4 or
+         IPv6 addresses, respectively.";
+    }
+    leaf local-port {
+      type inet:port-number;
+      default "0";
+      description
+        "The local port number to listen on for incoming TCP
+         client connections.  An invalid default value (0)
+         is used (instead of 'mandatory true') so that an
+         application level data model may 'refine' it with
+         an application specific default port number value.";
+    }
+    uses tcpcmn:tcp-connection-grouping {
+      augment "keepalives" {
+        if-feature "tcp-server-keepalives";
+        description
+          "Add an if-feature statement so that implementations
+           can choose to support TCP server keepalives.";
+      }
+    }
+  }
+}

--- a/test/lux/eng-25448_deviated_type_scope/run.lux
+++ b/test/lux/eng-25448_deviated_type_scope/run.lux
@@ -1,0 +1,7 @@
+[doc Test local typedef can be found in deviation]
+
+[shell yanger]
+    -error
+    !yanger cli-server.yang
+    !echo ==$$?==
+    ?==0==


### PR DESCRIPTION
This commit makes sure that any statements in a deviation gets resolved in deviating module scope.
If errors are found it will fallback to old behaviour and if this works then a warning is given.
The warning is because there's an import or typedef missing from the deviating module.