### PR TITLE
Add --depend-recurse option to depend plugin

### DIFF
--- a/plugins/yanger_depend.erl
+++ b/plugins/yanger_depend.erl
@@ -63,12 +63,11 @@ emit_prereqs(Ctx, Opts, [PreReq | T], Fd) ->
                     true ->
                         {value, M} = yang:get_module(PreReq, undefined, Ctx),
                         FName = yang:get_filename(M),
-                        {ok, Cwd} = file:get_cwd(),
                         case proplists:get_value(depend_extension, Opts) of
                             undefined ->
-                                filelib:safe_relative_path(FName, Cwd);
+                                FName;
                             Ext ->
-                                filelib:safe_relative_path(filename:rootname(FName) ++ Ext, Cwd)
+                                filename:rootname(FName) ++ Ext
                         end;
                     false ->
                         case proplists:get_value(depend_extension, Opts) of

--- a/plugins/yanger_depend.erl
+++ b/plugins/yanger_depend.erl
@@ -63,11 +63,12 @@ emit_prereqs(Ctx, Opts, [PreReq | T], Fd) ->
                     true ->
                         {value, M} = yang:get_module(PreReq, undefined, Ctx),
                         FName = yang:get_filename(M),
+                        {ok, Cwd} = file:get_cwd(),
                         case proplists:get_value(depend_extension, Opts) of
                             undefined ->
-                                FName;
+                                filelib:safe_relative_path(FName, Cwd);
                             Ext ->
-                                filename:rootname(FName) ++ Ext
+                                filelib:safe_relative_path(filename:rootname(FName) ++ Ext, Cwd)
                         end;
                     false ->
                         case proplists:get_value(depend_extension, Opts) of

--- a/plugins/yanger_depend.erl
+++ b/plugins/yanger_depend.erl
@@ -1,6 +1,8 @@
 -module(yanger_depend).
 -behaviour(yanger_plugin).
 
+-import(lists,[merge/1]).
+-import(lists,[usort/1]).
 -export([init/1]).
 
 -include_lib("yanger/include/yang.hrl").
@@ -18,6 +20,8 @@ option_specs() ->
         "Makefile rule target"},
        {depend_no_submodules, undefined, "depend-no-submodules", boolean,
         "Do not generate dependencies for included submodules"},
+       {depend_recurse, undefined, "depend-recurse", boolean,
+        "Generate dependencies to all imports recursively"},
        {depend_extension, undefined, "depend-extension", string,
         "YANG module file name extension"},
        {depend_include_path, undefined, "depend-include-path", boolean,
@@ -41,7 +45,7 @@ emit_mods(Ctx, Opts, [M | T], Fd) ->
             true -> "::";
             false -> ":"
         end,
-    PreReqs = get_prereqs(Opts, M),
+    PreReqs = get_prereqs(Ctx, Opts, M, []),
     io:format(Fd, "~s ~s", [DepTgt, ColonStr]),
     emit_prereqs(Ctx, Opts, PreReqs, Fd),
     emit_mods(Ctx, Opts, T, Fd);
@@ -79,7 +83,7 @@ emit_prereqs(Ctx, Opts, [PreReq | T], Fd) ->
 emit_prereqs(_Ctx, _Opts, [], Fd) ->
     io:format(Fd, "~n", []).
 
-get_prereqs(Opts, #module{stmt = Stmt}) ->
+get_prereqs(Ctx, Opts, #module{stmt = Stmt}, PreReqs) ->
     Imports = yang:search_all_stmts('import', Stmt),
     Includes =
         case proplists:get_value(depend_no_submodules, Opts, false) of
@@ -88,4 +92,11 @@ get_prereqs(Opts, #module{stmt = Stmt}) ->
             false ->
                 yang:search_all_stmts('include', Stmt)
         end,
-    [yang:stmt_arg(S) || S <- Imports ++ Includes].
+    NewPreReqs = [ T || T <- [yang:stmt_arg(S) || S <- Imports ++ Includes], lists:member(T, PreReqs) == false],
+    case proplists:get_value(depend_recurse, Opts, false) of
+        true ->
+            Models = [ yang:get_module(S, undefined, Ctx) || S <- NewPreReqs ], 
+            usort(PreReqs ++ merge([get_prereqs(Ctx, Opts, M, PreReqs ++ NewPreReqs) || {value, M}  <- Models]));
+        false ->
+            PreReqs ++ NewPreReqs
+    end.

--- a/test/lux/depend/Makefile
+++ b/test/lux/depend/Makefile
@@ -1,0 +1,8 @@
+include ../../support/*_testcases.mk
+
+build:
+
+clean:
+	rm -rf lux_logs _tmp_*
+
+.PHONY: build clean

--- a/test/lux/depend/a.yang
+++ b/test/lux/depend/a.yang
@@ -1,0 +1,14 @@
+module a {
+  namespace urn:a;
+  prefix a;
+
+  import b {
+    prefix b;
+  }
+  import c {
+    prefix c;
+  }
+
+  include d;
+  include f;
+}

--- a/test/lux/depend/b.yang
+++ b/test/lux/depend/b.yang
@@ -1,0 +1,14 @@
+module b {
+  namespace urn:b;
+  prefix b1;
+
+  import c {
+    prefix c1; // NOTE: different prefix than in a.yang when b:b is used.
+  }
+
+  import e {
+    prefix e;
+  }
+
+  include g;
+}

--- a/test/lux/depend/c.yang
+++ b/test/lux/depend/c.yang
@@ -1,0 +1,4 @@
+module c {
+  namespace urn:c;
+  prefix c2;
+}

--- a/test/lux/depend/d.yang
+++ b/test/lux/depend/d.yang
@@ -1,0 +1,5 @@
+submodule d {
+  belongs-to a {
+    prefix a;
+  }
+}

--- a/test/lux/depend/d.yang
+++ b/test/lux/depend/d.yang
@@ -2,4 +2,6 @@ submodule d {
   belongs-to a {
     prefix a;
   }
+
+  include f;
 }

--- a/test/lux/depend/e.yang
+++ b/test/lux/depend/e.yang
@@ -1,0 +1,8 @@
+module e {
+  namespace urn:e;
+  prefix e;
+
+  import c {
+    prefix c; // NOTE: different prefix than in a.yang when b:b is used.
+  }
+}

--- a/test/lux/depend/f.yang
+++ b/test/lux/depend/f.yang
@@ -1,0 +1,5 @@
+submodule f {
+  belongs-to a {
+    prefix a;
+  }
+}

--- a/test/lux/depend/g.yang
+++ b/test/lux/depend/g.yang
@@ -1,0 +1,5 @@
+submodule g {
+  belongs-to b {
+    prefix b;
+  }
+}

--- a/test/lux/depend/run.lux
+++ b/test/lux/depend/run.lux
@@ -1,0 +1,50 @@
+[doc test depend plugin]
+
+[shell test]
+    !yanger -f depend a.yang
+    """??
+    a.yang : b c d f
+    SH-PROMPT
+    """
+
+    !yanger -f depend --depend-no-submodules a.yang
+    """??
+    a.yang : b c
+    SH-PROMPT
+    """
+
+    !yanger -f depend --depend-no-submodules --depend-recurse a.yang
+    """??
+    a.yang : b c e
+    SH-PROMPT
+    """
+
+    !yanger -f depend --depend-recurse a.yang
+    """??
+    a.yang : b c d e f g
+    SH-PROMPT
+    """
+
+    !yanger -f depend --depend-recurse --depend-ignore-module b a.yang
+    """??
+    a.yang : c d e f g
+    SH-PROMPT
+    """
+    
+    !yanger -f depend --depend-recurse --depend-extension _test a.yang
+    """??
+    a.yang : b_test c_test d_test e_test f_test g_test
+    SH-PROMPT
+    """
+    
+    !yanger -f depend --depend-recurse --depend-include-path --depend-double-colon a.yang
+    """??
+    a.yang :: ./b.yang ./c.yang ./d.yang ./e.yang ./f.yang ./g.yang
+    SH-PROMPT
+    """
+   
+    !yanger -f depend --depend-target test_target --depend-double-colon --depend-recurse --depend-extension _test a.yang
+    """??
+    test_target :: b_test c_test d_test e_test f_test g_test
+    SH-PROMPT
+    """

--- a/test/lux/depend/run.lux
+++ b/test/lux/depend/run.lux
@@ -31,20 +31,26 @@
     SH-PROMPT
     """
     
-    !yanger -f depend --depend-recurse --depend-extension _test a.yang
+    !yanger -f depend --depend-recurse --depend-extension .test a.yang
     """??
-    a.yang : b_test c_test d_test e_test f_test g_test
+    a.yang : b.test c.test d.test e.test f.test g.test
     SH-PROMPT
     """
     
     !yanger -f depend --depend-recurse --depend-include-path --depend-double-colon a.yang
     """??
-    a.yang :: ./b.yang ./c.yang ./d.yang ./e.yang ./f.yang ./g.yang
+    a.yang :: b.yang c.yang d.yang e.yang f.yang g.yang
+    SH-PROMPT
+    """
+
+    !yanger -f depend --depend-recurse --depend-include-path --depend-extension .test a.yang
+    """??
+    a.yang :: b.test c.test d.test e.test f.test g.test
     SH-PROMPT
     """
    
-    !yanger -f depend --depend-target test_target --depend-double-colon --depend-recurse --depend-extension _test a.yang
+    !yanger -f depend --depend-target test_target a.yang
     """??
-    test_target :: b_test c_test d_test e_test f_test g_test
+    test_target :: b c d f
     SH-PROMPT
     """

--- a/test/lux/depend/run.lux
+++ b/test/lux/depend/run.lux
@@ -45,12 +45,12 @@
 
     !yanger -f depend --depend-recurse --depend-include-path --depend-extension .test a.yang
     """??
-    a.yang :: b.test c.test d.test e.test f.test g.test
+    a.yang : b.test c.test d.test e.test f.test g.test
     SH-PROMPT
     """
    
     !yanger -f depend --depend-target test_target a.yang
     """??
-    test_target :: b c d f
+    test_target : b c d f
     SH-PROMPT
     """

--- a/test/lux/depend/run.lux
+++ b/test/lux/depend/run.lux
@@ -39,13 +39,13 @@
     
     !yanger -f depend --depend-recurse --depend-include-path --depend-double-colon a.yang
     """??
-    a.yang :: b.yang c.yang d.yang e.yang f.yang g.yang
+    a.yang :: ./b.yang ./c.yang ./d.yang ./e.yang ./f.yang ./g.yang
     SH-PROMPT
     """
 
     !yanger -f depend --depend-recurse --depend-include-path --depend-extension .test a.yang
     """??
-    a.yang : b.test c.test d.test e.test f.test g.test
+    a.yang : ./b.test ./c.test ./d.test ./e.test ./f.test ./g.test
     SH-PROMPT
     """
    


### PR DESCRIPTION
Proposed fix for this issue: https://github.com/mbj4668/yanger/issues/30

The intent is to add --depend-recurse to the depend plugin along with a bunch of tests for the depend plugin - I was unable to find any pre-existing tests for this plugin.

Would be happy to get some input on this line where get_prereqs is called recursively for all the newly discovered prereqs:
usort(PreReqs ++ merge([get_prereqs(Ctx, Opts, M, PreReqs ++ NewPreReqs) || {value, M}  <- Models]));

The merge is used to convert the list-of-lists into a single list and then usort is applied to remove the duplicate entries in the list ... if there is a better way I'd be happy to try it out.  :)

I also noticed in the test output that with "--depend-include-path" the output with yanger is different than pyang - which also affects the use-case we're testing. Will raise another issue to track that.