### PR TITLE
yanger falsely warns about non existing nodes, when they exist

### DIFF
--- a/test/lux/submodule-xpath-ref-parent-faulty-warning/A.yang
+++ b/test/lux/submodule-xpath-ref-parent-faulty-warning/A.yang
@@ -1,0 +1,12 @@
+module A {
+  namespace "yang:err";
+  prefix "A";
+  include "B";
+
+  container test {
+    leaf feature {
+      type boolean;
+      default false;
+    }
+  }
+}

--- a/test/lux/submodule-xpath-ref-parent-faulty-warning/B.yang
+++ b/test/lux/submodule-xpath-ref-parent-faulty-warning/B.yang
@@ -1,0 +1,13 @@
+submodule B {
+
+  belongs-to A {
+    prefix A;
+  }
+
+  container new-test-features {
+    when "/A:test/A:feature = 'true'";
+    leaf foo {
+      type string;
+    }
+  }
+}

--- a/test/lux/submodule-xpath-ref-parent-faulty-warning/Makefile
+++ b/test/lux/submodule-xpath-ref-parent-faulty-warning/Makefile
@@ -1,0 +1,8 @@
+include ../../support/*_testcases.mk
+
+build:
+
+clean:
+	rm -rf lux_logs
+
+.PHONY: build clean

--- a/test/lux/submodule-xpath-ref-parent-faulty-warning/run.lux
+++ b/test/lux/submodule-xpath-ref-parent-faulty-warning/run.lux
@@ -1,0 +1,16 @@
+[doc]
+submodule with XPath referencing owning module, false warning
+
+We have a module and a submodule, where the submodule has a node with
+a when expression to the module. This should not give a warning that
+the target of the when expression does not exist.
+[enddoc]
+
+[shell compilation]
+    -warning
+    !yanger A.yang
+    !echo "==$$?=="
+    ?==0==
+    !yanger B.yang
+    !echo "==$$?=="
+    ?==0==


### PR DESCRIPTION
This is when nodes in submodules refer to nodes in the "belongs-to"/owning module.

The idea of the diff is that rather than looking at only the children defined in the submodule, we can look at these *and* also look at the nodes defined in the module we (the submodule) belong to. (but we still do not want to look at any children defined in other submodules included by the same owning module)

This is only an issue in YANG 1.0, since for YANG 1.1 submodules, yanger does this:

```
if M#module.yang_version == '1.1' orelse IsModule ->
    Ctx_1 = update_conditional_hooks(Ctx_0, M),
    Ctx_2 = post_expand_module(M, Ctx_1),
    Ctx_2#yctx{hooks = OrigHooks};
  true -> % submodule, version >= 1.1, don't check here;
    %% instead, checks on the SNs that are defined in
    %% this submodule, are done while processing the
    %% module that this submodule belongs to. See:
    %% post_expand_sn/4 function.
  Ctx_0
end
```

I use yang:search_module in the diff rather than yang:get_module, this is because if you give only the submodule to yanger, it will not have loaded the "owning" module, and yang:get_module will not return the module.

@mbj4668 If you think yanger should automatically load the owning/belongs-to module when given a submodule, then I can investigate that. I don't know if it doesn't currently due to memory constraints?