### PR TITLE
Adjust augmented xpath-expressions

### DIFF
--- a/src/yang_xpath.erl
+++ b/src/yang_xpath.erl
@@ -3,6 +3,7 @@
 -export([mk_ns_map/1,
          compile/2, compile/5,
          set_default_namespace/2,
+         shift_xp_current/2,
          get_dep_paths/2, v_dep_path/6]).
 
 -export_type([ns_map/0]).
@@ -409,6 +410,10 @@ dep_path_to_cursor_path0([], _) ->
 is_dep_path_absolute(['..' | _]) -> false;
 is_dep_path_absolute(['.' | _]) -> false;
 is_dep_path_absolute(_) -> true.
+
+
+shift_xp_current(XPath, 0) -> XPath;
+shift_xp_current(XPath, N) -> xpath_rewrite:shift_current_expr(XPath, N).
 
 
 -ifdef(debug).


### PR DESCRIPTION
For an augmenting model with an augment like:

  augment "/foo:routing-instances/foo:routing-instance" {
    when "/if:interfaces/if:interface[if:name=current()/foo:interfaces/foo:interface/foo:name]/if:type = 'access'";
    leaf default-access {
      type boolean;
    }
  }

Yanger compiled this and checks the xpath which is ok, then the
when-expression will be "moved into" the default-access leaf.  But
this means the XPATH-expression is no longer correct, because the
function "current()":s context-node has now moved one step.

To fix this we walk through the xpath-expression and correct *all*
"current()" by inserting apropriate number of parent-steps ("../").