### PR TITLE
YANG 1.1 submodules: Relax circular dependency errors.

### DIFF
--- a/test/lux/include-circular-dep/Makefile
+++ b/test/lux/include-circular-dep/Makefile
@@ -1,0 +1,8 @@
+include ../../support/*_testcases.mk
+
+build:
+
+clean:
+	rm -rf lux_logs _tmp_*
+
+.PHONY: build clean

--- a/test/lux/include-circular-dep/direct-yang-1.1/my-mod.yang
+++ b/test/lux/include-circular-dep/direct-yang-1.1/my-mod.yang
@@ -1,0 +1,17 @@
+module my-mod {
+
+  yang-version "1.1";
+
+  namespace "my:nice:conf";
+
+  prefix "mod";
+
+  include my-sub1;
+  include my-sub2;
+
+  container configure {
+    leaf hello {
+      type string;
+    }
+  }
+}

--- a/test/lux/include-circular-dep/direct-yang-1.1/my-sub1.yang
+++ b/test/lux/include-circular-dep/direct-yang-1.1/my-sub1.yang
@@ -1,0 +1,18 @@
+submodule my-sub1 {
+
+  yang-version "1.1";
+
+  belongs-to my-mod { prefix "mod"; }
+
+  include my-sub2;
+
+  grouping sub1-grouping {
+    container a {
+      leaf b {
+        type boolean;
+      }
+    }
+  }
+
+  uses sub2-grouping;
+}

--- a/test/lux/include-circular-dep/direct-yang-1.1/my-sub2.yang
+++ b/test/lux/include-circular-dep/direct-yang-1.1/my-sub2.yang
@@ -1,0 +1,22 @@
+submodule my-sub2 {
+
+  yang-version "1.1";
+
+  belongs-to my-mod { prefix "mod"; }
+
+  include my-sub1;
+
+  grouping sub2-grouping {
+    container c {
+      leaf d {
+        type string;
+      }
+    }
+  }
+
+  // FIXME: Currently not possible to use sub1-grouping, it depends
+  //        on the ordering
+  //        of include statements in the parent module (my-mod.yang)
+  //
+  // uses sub1-grouping;
+}

--- a/test/lux/include-circular-dep/direct-yang-1/my-mod.yang
+++ b/test/lux/include-circular-dep/direct-yang-1/my-mod.yang
@@ -1,0 +1,15 @@
+module my-mod {
+
+  namespace "my:nice:conf";
+
+  prefix "mod";
+
+  include my-sub1;
+  include my-sub2;
+
+  container configure {
+    leaf hello {
+      type string;
+    }
+  }
+}

--- a/test/lux/include-circular-dep/direct-yang-1/my-sub1.yang
+++ b/test/lux/include-circular-dep/direct-yang-1/my-sub1.yang
@@ -1,0 +1,16 @@
+submodule my-sub1 {
+
+  belongs-to my-mod { prefix "mod"; }
+
+  include my-sub2;
+
+  grouping sub1-grouping {
+    container a {
+      leaf b {
+        type boolean;
+      }
+    }
+  }
+
+  uses sub2-grouping;
+}

--- a/test/lux/include-circular-dep/direct-yang-1/my-sub2.yang
+++ b/test/lux/include-circular-dep/direct-yang-1/my-sub2.yang
@@ -1,0 +1,20 @@
+submodule my-sub2 {
+
+  belongs-to my-mod { prefix "mod"; }
+
+  include my-sub1;
+
+  grouping sub2-grouping {
+    container c {
+      leaf d {
+        type string;
+      }
+    }
+  }
+
+  // FIXME: Currently not possible to use sub1-grouping, it depends
+  //        on the ordering
+  //        of include statements in the parent module (my-mod.yang)
+  //
+  // uses sub1-grouping;
+}

--- a/test/lux/include-circular-dep/indirect-yang-1.1/my-mod.yang
+++ b/test/lux/include-circular-dep/indirect-yang-1.1/my-mod.yang
@@ -1,0 +1,18 @@
+module my-mod {
+
+  yang-version "1.1";
+
+  namespace "my:nice:conf";
+
+  prefix "mod";
+
+  include my-sub1;
+  include my-sub2;
+  include my-sub3;
+
+  container configure {
+    leaf hello {
+      type string;
+    }
+  }
+}

--- a/test/lux/include-circular-dep/indirect-yang-1.1/my-sub1.yang
+++ b/test/lux/include-circular-dep/indirect-yang-1.1/my-sub1.yang
@@ -1,0 +1,16 @@
+submodule my-sub1 {
+
+  yang-version "1.1";
+
+  belongs-to my-mod { prefix "mod"; }
+
+  include my-sub3;
+
+  grouping sub1-grouping {
+    container a {
+      leaf x {
+        type boolean;
+      }
+    }
+  }
+}

--- a/test/lux/include-circular-dep/indirect-yang-1.1/my-sub2.yang
+++ b/test/lux/include-circular-dep/indirect-yang-1.1/my-sub2.yang
@@ -1,0 +1,16 @@
+submodule my-sub2 {
+
+  yang-version "1.1";
+
+  belongs-to my-mod { prefix "mod"; }
+
+  include my-sub1;
+
+  grouping sub2-grouping {
+    container b {
+      leaf y {
+        type string;
+      }
+    }
+  }
+}

--- a/test/lux/include-circular-dep/indirect-yang-1.1/my-sub3.yang
+++ b/test/lux/include-circular-dep/indirect-yang-1.1/my-sub3.yang
@@ -1,0 +1,16 @@
+submodule my-sub3 {
+
+  yang-version "1.1";
+
+  belongs-to my-mod { prefix "mod"; }
+
+  include my-sub2;
+
+  grouping sub3-grouping {
+    container c {
+      leaf z {
+        type string;
+      }
+    }
+  }
+}

--- a/test/lux/include-circular-dep/indirect-yang-1/my-mod.yang
+++ b/test/lux/include-circular-dep/indirect-yang-1/my-mod.yang
@@ -1,0 +1,16 @@
+module my-mod {
+
+  namespace "my:nice:conf";
+
+  prefix "mod";
+
+  include my-sub1;
+  include my-sub2;
+  include my-sub3;
+
+  container configure {
+    leaf hello {
+      type string;
+    }
+  }
+}

--- a/test/lux/include-circular-dep/indirect-yang-1/my-sub1.yang
+++ b/test/lux/include-circular-dep/indirect-yang-1/my-sub1.yang
@@ -1,0 +1,14 @@
+submodule my-sub1 {
+
+  belongs-to my-mod { prefix "mod"; }
+
+  include my-sub3;
+
+  grouping sub1-grouping {
+    container a {
+      leaf x {
+        type boolean;
+      }
+    }
+  }
+}

--- a/test/lux/include-circular-dep/indirect-yang-1/my-sub2.yang
+++ b/test/lux/include-circular-dep/indirect-yang-1/my-sub2.yang
@@ -1,0 +1,14 @@
+submodule my-sub2 {
+
+  belongs-to my-mod { prefix "mod"; }
+
+  include my-sub1;
+
+  grouping sub2-grouping {
+    container b {
+      leaf y {
+        type string;
+      }
+    }
+  }
+}

--- a/test/lux/include-circular-dep/indirect-yang-1/my-sub3.yang
+++ b/test/lux/include-circular-dep/indirect-yang-1/my-sub3.yang
@@ -1,0 +1,14 @@
+submodule my-sub3 {
+
+  belongs-to my-mod { prefix "mod"; }
+
+  include my-sub2;
+
+  grouping sub3-grouping {
+    container c {
+      leaf z {
+        type string;
+      }
+    }
+  }
+}

--- a/test/lux/include-circular-dep/run.lux
+++ b/test/lux/include-circular-dep/run.lux
@@ -1,0 +1,53 @@
+[doc]
+YANG 1.1 Submodules including each other should not cause circular \
+dep errors, but YANG 1.0 submodules should.
+
+RFC6020 (YANG 1.0):
+
+   There MUST NOT be any circular chains of imports or includes.  For
+   example, if submodule "a" includes submodule "b", "b" cannot include
+   "a".
+
+RFC7950 (YANG 1.1):
+
+   o  Changed the scoping rules for definitions in submodules. A
+      submodule can now reference all definitions in all submodules that
+      belong to the same module, without using the "include" statement.
+
+   o  For backward compatibility with YANG version 1, a submodule is allowed to
+      include another submodule belonging to the same module, but this is not
+      necessary in YANG version 1.1 (see Section 5.1).
+
+   o  There MUST NOT be any circular chains of imports.  For example, if
+      module "a" imports module "b", "b" cannot import "a".
+
+[enddoc]
+
+[macro ok]
+    !echo $?
+    ???0
+    ?SH-PROMPT:
+[endmacro]
+
+[macro not-ok]
+    !echo $?
+    ???1
+    ?SH-PROMPT:
+[endmacro]
+
+[shell compile-1.1]
+    -circular dependency for submodule
+    !yanger -p indirect-yang-1.1 indirect-yang-1.1/my-mod.yang
+    [invoke ok]
+
+    !yanger -p direct-yang-1.1 direct-yang-1.1/my-mod.yang
+    [invoke ok]
+
+[shell compile-1]
+    !yanger -p indirect-yang-1 indirect-yang-1/my-mod.yang
+    ???indirect-yang-1/my-sub2.yang:5: error: circular dependency for submodule 'my-sub1'
+    [invoke not-ok]
+
+    !yanger -p direct-yang-1 direct-yang-1/my-mod.yang
+    ???direct-yang-1/my-sub2.yang:5: error: circular dependency for submodule 'my-sub1'
+    [invoke not-ok]


### PR DESCRIPTION
**Background**

It is currently not possible to compile models for Nokia SROS using yanger. This is because they typically have multiple submodules belonging to the same module, including each other. 

**Reproduction**

The Nokia SROS Yang models are accessible from github:

url:  https://github.com/nokia/7x50_YangModels.git

checkout: sros_20.5.r1

subdir: YANG

cd YANG && yanger nokia-conf.yang

```tmp-yang/config/nokia-conf-bmp.yang:11: error: circular dependency for submodule 'nokia-conf-system'
tmp-yang/config/nokia-conf-bmp.yang:12: error: circular dependency for submodule 'nokia-conf-system-security'
tmp-yang/config/nokia-conf-filter.yang:17: error: circular dependency for submodule 'nokia-conf-log'
tmp-yang/config/nokia-conf-filter.yang:19: error: circular dependency for submodule 'nokia-conf-service'
tmp-yang/config/nokia-conf-ipsec.yang:13: error: circular dependency for submodule 'nokia-conf-aaa'
tmp-yang/config/nokia-conf-ipsec.yang:15: error: circular dependency for submodule 'nokia-conf-system'
tmp-yang/config/nokia-conf-ipsec.yang:16: error: circular dependency for submodule 'nokia-conf-system-security'
tmp-yang/config/nokia-conf-isa.yang:14: error: circular dependency for submodule 'nokia-conf-aaa'
tmp-yang/config/nokia-conf-lag.yang:15: error: circular dependency for submodule 'nokia-conf-port'
tmp-yang/config/nokia-conf-lag.yang:16: error: circular dependency for submodule 'nokia-conf-service'
tmp-yang/config/nokia-conf-log.yang:13: error: circular dependency for submodule 'nokia-conf-python'
tmp-yang/config/nokia-conf-openflow.yang:65: warning: the default value for a key leaf is ignored
tmp-yang/config/nokia-conf-port-eth-access.yang:13: error: circular dependency for submodule 'nokia-conf-log'
tmp-yang/config/nokia-conf-port-eth-access.yang:14: error: circular dependency for submodule 'nokia-conf-port'
tmp-yang/config/nokia-conf-port-eth-access.yang:16: error: circular dependency for submodule 'nokia-conf-port-ethernet'
tmp-yang/config/nokia-conf-port-eth-dot1x.yang:12: error: circular dependency for submodule 'nokia-conf-aaa'
tmp-yang/config/nokia-conf-port-eth-dot1x.yang:15: error: circular dependency for submodule 'nokia-conf-system'
tmp-yang/config/nokia-conf-port-eth-network.yang:12: error: circular dependency for submodule 'nokia-conf-log'
tmp-yang/config/nokia-conf-port-ethernet.yang:17: error: circular dependency for submodule 'nokia-conf-log'
tmp-yang/config/nokia-conf-port-sonet.yang:15: error: circular dependency for submodule 'nokia-conf-log'
tmp-yang/config/nokia-conf-port-tdm.yang:14: error: circular dependency for submodule 'nokia-conf-log'
tmp-yang/config/nokia-conf-pw-port.yang:14: error: circular dependency for submodule 'nokia-conf-service'
```

**Proposed change:**
    YANG 1.1 submodules including each other should not cause circular
    dep errors, but YANG 1.0 submodules should.

**Testing**

Minimal version of the Nokia YANG models attached and are run as lux tests

**RFC Support:**

    RFC6020 (YANG 1.0):

       There MUST NOT be any circular chains of imports or includes.  For
       example, if submodule "a" includes submodule "b", "b" cannot include
       "a".

    RFC7950 (YANG 1.1):

       o  Changed the scoping rules for definitions in submodules. A
          submodule can now reference all definitions in all submodules that
          belong to the same module, without using the "include" statement.

       o  For backward compatibility with YANG version 1, a submodule is
          allowed to include another submodule belonging to the same module,
          but this is not in YANG version 1.1 (see Section 5.1).

       o  There MUST NOT be any circular chains of imports.  For example, if
          module "a" imports module "b", "b" cannot import "a".