### PR TITLE
Fix yanger crash when refining a container with a default value

### DIFF
--- a/test/lux/refine/bad.yang
+++ b/test/lux/refine/bad.yang
@@ -30,6 +30,9 @@ module bad {
       min-elements 10;
       max-elements 2; // error: max-elements < min-elements
     }
+    refine a {
+      default 32;
+    }
   }
 
   grouping b {

--- a/test/lux/refine/refine.lux
+++ b/test/lux/refine/refine.lux
@@ -75,8 +75,9 @@ module ref {
     ??bad.yang:17: (from bad.yang:23): YANG_ERR_INVALID_CONFIG
     ?bad.yang:22: YANG_ERR_TYPE_VALUE
     ?bad.yang:24: YANG_ERR_XPATH
-    ?bad.yang:38: YANG_ERR_TYPE_VALUE
-    ?bad.yang:59: YANG_ERR_TYPE_VALUE
+    ?bad.yang:34: YANG_ERR_ILLEGAL_REFINE
+    ?bad.yang:41: YANG_ERR_TYPE_VALUE
+    ?bad.yang:62: YANG_ERR_TYPE_VALUE
     -bad.yang
     ?SH-PROMPT
 


### PR DESCRIPTION
Yanger crashes if one tries to refine a container with a defaukt value. This PR fixes this.